### PR TITLE
Fix for Issue#2 - Import Package Update

### DIFF
--- a/Import/FindParentPackage/Import/Item Action/2150E6F89364418AB1F95AD1A13F5DD0.xml
+++ b/Import/FindParentPackage/Import/Item Action/2150E6F89364418AB1F95AD1A13F5DD0.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="2150E6F89364418AB1F95AD1A13F5DD0" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="gn_ViewCard" type="ItemType" name="gn_ViewCard">B5B1E4E180CF43A986D05ED063EA7D67</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/2DF4C0A0707A43729158DC4380FA7DA3.xml
+++ b/Import/FindParentPackage/Import/Item Action/2DF4C0A0707A43729158DC4380FA7DA3.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="2DF4C0A0707A43729158DC4380FA7DA3" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>384</sort_order>
+  <source_id keyed_name="rb_TreeGridViewDefinition" type="ItemType" name="rb_TreeGridViewDefinition">6AFE8A9127ED48FFB2F9183B9922981B</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/38163688CF16419E8D9B63AD86332AA2.xml
+++ b/Import/FindParentPackage/Import/Item Action/38163688CF16419E8D9B63AD86332AA2.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="38163688CF16419E8D9B63AD86332AA2" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="gn_NodeType" type="ItemType" name="gn_NodeType">ACE6EA7108E04C16BF7C2BCB2B7234B6</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/47756D2E54EA4DD29593411627CAD30F.xml
+++ b/Import/FindParentPackage/Import/Item Action/47756D2E54EA4DD29593411627CAD30F.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="47756D2E54EA4DD29593411627CAD30F" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="gn_ConnectorViewDefinition" type="ItemType" name="gn_ConnectorViewDefinition">17A499D45EF34ACBA65914A8F57238F1</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/49DC5A9D9D8645F9ACB91C0A311A7C2C.xml
+++ b/Import/FindParentPackage/Import/Item Action/49DC5A9D9D8645F9ACB91C0A311A7C2C.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="49DC5A9D9D8645F9ACB91C0A311A7C2C" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="gn_ConnectorType" type="ItemType" name="gn_ConnectorType">A21B17137F49452A872619217200D9F1</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/602C5FDE0EEC42678E53833F8ABCC89A.xml
+++ b/Import/FindParentPackage/Import/Item Action/602C5FDE0EEC42678E53833F8ABCC89A.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="602C5FDE0EEC42678E53833F8ABCC89A" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="gn_GraphViewDefinition" type="ItemType" name="gn_GraphViewDefinition">6DAD626079124665A0B219FFE673052C</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/60A59F6E59494F3C8FB00B5D005E6514.xml
+++ b/Import/FindParentPackage/Import/Item Action/60A59F6E59494F3C8FB00B5D005E6514.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="60A59F6E59494F3C8FB00B5D005E6514" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="gn_SystemDefaultCard" type="ItemType" name="gn_SystemDefaultCard">BB9C415B65E0480C96C99C07EB3FCA88</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/B4E6FC0C255E4E3287A0A985BFE0D538.xml
+++ b/Import/FindParentPackage/Import/Item Action/B4E6FC0C255E4E3287A0A985BFE0D538.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="B4E6FC0C255E4E3287A0A985BFE0D538" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="gn_NodeViewDefinition" type="ItemType" name="gn_NodeViewDefinition">E3B78447EB16474BBCCC55785B030828</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/B784464C517449FABF716FFC11ACF2C7.xml
+++ b/Import/FindParentPackage/Import/Item Action/B784464C517449FABF716FFC11ACF2C7.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="B784464C517449FABF716FFC11ACF2C7" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="qry_QueryDefinition" type="ItemType" name="qry_QueryDefinition">0421B558114B4B22886C0F4206C923EE</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/E852004E5E2642A8B8293CD28C8BAC76.xml
+++ b/Import/FindParentPackage/Import/Item Action/E852004E5E2642A8B8293CD28C8BAC76.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="E852004E5E2642A8B8293CD28C8BAC76" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="rb_UI_ActivateTgvdWizard" type="ItemType" name="rb_UI_ActivateTgvdWizard">9D079C239C6540ED889DC7D5E5FE283A</source_id>
+ </Item>
+</AML>

--- a/Import/FindParentPackage/Import/Item Action/F8D55C9183A747DF8B1C9CFC229B9EB8.xml
+++ b/Import/FindParentPackage/Import/Item Action/F8D55C9183A747DF8B1C9CFC229B9EB8.xml
@@ -1,0 +1,21 @@
+﻿<AML>
+ <Item type="Item Action" id="F8D55C9183A747DF8B1C9CFC229B9EB8" action="add">
+  <related_id keyed_name="labs_FindParentPackage" type="Action">
+   <Item type="Action" id="7E41725E177B4C04ADF87906B033900F" action="add">
+    <item_query>&lt;Item type="{@type}" id="{@id}" levels= "1" action="get" select="config_id" /&gt;</item_query>
+    <label xml:lang="en">Find Parent Package</label>
+    <location>client</location>
+    <method keyed_name="labs_FindParentPackage" type="Method">
+     <Item type="Method" action="get" select="id">
+      <name>labs_FindParentPackage</name>
+     </Item>
+    </method>
+    <target>none</target>
+    <type>item</type>
+    <name>labs_FindParentPackage</name>
+   </Item>
+  </related_id>
+  <sort_order>128</sort_order>
+  <source_id keyed_name="Sequence" type="ItemType" name="Sequence">2B46201802CE46708C269667DB4798AC</source_id>
+ </Item>
+</AML>


### PR DESCRIPTION
ItemTypes Query Definition, Tree Grid View, and Graph Navigation will now have the FindParentPackage item action available by default.
Additionally, the method now works for Items of ItemType Sequence.  The README file said it supported this ItemType but didn't until now.